### PR TITLE
fix(backend): close watchlist-monitoring IDOR + harden top backend-audit findings

### DIFF
--- a/.claude/agents/backend-auditor.md
+++ b/.claude/agents/backend-auditor.md
@@ -39,11 +39,14 @@ with intent rather than your own preferences:
 
 1. `apps/backend/CLAUDE.md` and the root `CLAUDE.md`
 2. `.claude/skills/backend-patterns/SKILL.md` — the canonical DDD/CQRS/value-object/
-   repository/use-case/module patterns
-3. `.claude/skills/backend-testing/SKILL.md` — the canonical unit / integration /
+   repository/use-case/module patterns (incl. the domain-error taxonomy and the
+   `src/common/errors` + `DomainErrorFilter` HTTP mapping)
+3. `.claude/skills/backend-security/SKILL.md` — the canonical auth/ownership rules
+   (authN ≠ authZ, IDOR, child-resource ownership, `@Public()` justification)
+4. `.claude/skills/backend-testing/SKILL.md` — the canonical unit / integration /
    controller test conventions
 
-These three files are the source of truth. The checklist below restates their rules,
+These files are the source of truth. The checklist below restates their rules,
 but if the skills and this prompt ever disagree, the skills win — and flag the drift.
 
 ## Two-tier finding model (this is the core design — respect it)
@@ -61,13 +64,17 @@ real inconsistencies. So split every finding into one of two tiers:
   codebase ignores consistently. Report these **once**, in a separate section, with a
   representative example and a **site count** — never as N per-site findings.
 
-  Canonical Tier-2 example (already known to exist): ownership checks written as
-  `throw new Error('User does not own this ...')` in use-cases across `position`,
-  `watchlist`, and `watchlist-monitoring`. This produces an HTTP 500 instead of 403
-  and bypasses the domain-error taxonomy — but it is the *de-facto* pattern, so it is
-  NOT a per-site inconsistency. Emit ONE advisory: "bare-Error ownership check used in
-  N sites — consider a domain `AuthorizationError` mapped to a Nest `ForbiddenException`",
-  with the count and 2–3 representative paths. Do not flag each site.
+  Canonical Tier-2 example: a best practice the *whole* codebase ignores uniformly
+  (e.g. several analytics modules generating ids via `crypto.randomUUID()` inline
+  instead of `UuidGeneratorService`). Emit ONE advisory with the count and 2–3
+  representative paths; do not flag each site.
+
+  NOTE — convention has since changed: bare-`Error` ownership/not-found throws are
+  **no longer the norm**. The codebase now has `AuthorizationError`/`NotFoundError`
+  in `src/common/errors`, mapped to 403/404 by `DomainErrorFilter`. So a
+  `throw new Error('User does not own ...')` or `throw new Error('... not found')` in a
+  use-case is now a **Tier-1 violation** (it deviates from the established taxonomy and
+  silently returns 500), not a Tier-2 advisory. Flag each such site.
 
 **Consistency-first rule:** when you are unsure whether something is wrong, grep for
 how comparable modules do the same thing. If the majority do it the same way, it is at
@@ -104,9 +111,28 @@ most a Tier-2 advisory, not a Tier-1 violation.
 **Domain errors**
 
 - Bare `throw new Error(...)` for a *domain invariant / state / chronology* condition —
-  Tier 1 (should be `InvariantError` / `StateError` / `ChronologyError`, all extending
-  `DomainError`).
-- The *ownership/authorization* bare-Error variant — Tier 2 (see canonical example).
+  Tier 1 (should be `InvariantError` / `StateError` / `ChronologyError`).
+- Bare `throw new Error(...)` for an *ownership* condition — Tier 1 (should be
+  `AuthorizationError`, → 403).
+- Bare `throw new Error(...)` for a *not-found* condition after a null `findById` —
+  Tier 1 (should be `NotFoundError`, → 404).
+- A module's `domain/domain-errors.ts` redeclaring `DomainError extends Error` locally
+  instead of re-exporting the shared base from `src/common/errors` — Tier 1 (breaks the
+  single-identity guarantee `DomainErrorFilter` relies on for `instanceof`).
+
+**Authorization / ownership (cross-reference `backend-security` skill)**
+
+- A use-case that reads or mutates an *existing* resource but does **not** accept
+  `authContext` and verify ownership — **Blocking** (IDOR). Check both `execute(...)`'s
+  signature and the body for the `resource.userId.value !== authContext.userId.value`
+  guard. For child resources (entity has no `userId`), the check loads the *parent*
+  aggregate via its read repository — its absence is still Blocking.
+- A controller handler that accepts a resource id from the client but never reads
+  `req.user` / never passes `authContext` to the use-case — **Blocking** (the use-case
+  cannot check ownership without it).
+- A new `@Public()` endpoint that touches user-owned data — **Blocking**. A `@Public()`
+  endpoint that merely kicks off an expensive job (no user data) — Warning / note (the
+  two `stock-analysis` run endpoints are the known, accepted baseline).
 
 **DI / module wiring**
 

--- a/.claude/skills/backend-patterns/SKILL.md
+++ b/.claude/skills/backend-patterns/SKILL.md
@@ -39,15 +39,43 @@ Aggregate roots with business logic — never anemic. Private constructor, stati
 
 ## Domain Errors
 
-Use specific domain errors, never generic `Error`:
+Use specific domain errors, **never** generic `throw new Error(...)` in the domain or
+use-case layers. A bare `Error` becomes an HTTP 500; a `DomainError` is mapped to the
+right status by the global filter (see below).
 
-| Error | When |
-|-------|------|
-| `InvariantError` | Invalid data, business rule violated |
-| `StateError` | Operation invalid for current entity state |
-| `ChronologyError` | Event timestamp out of order |
+| Error | When | HTTP |
+|-------|------|------|
+| `InvariantError` | Invalid data, business rule violated | 400 |
+| `StateError` | Operation invalid for current entity state | 400 |
+| `ChronologyError` | Event timestamp out of order | 400 |
+| `AuthorizationError` | Caller authenticated but does not own / may not act on the resource | 403 |
+| `NotFoundError` | Requested resource does not exist | 404 |
 
-All extend `DomainError extends Error`.
+The shared base `DomainError`, plus the cross-cutting `AuthorizationError` and
+`NotFoundError`, live in **`src/common/errors`** (one identity app-wide). Module-specific
+errors (`InvariantError`, `StateError`, `ChronologyError`) live in each module's
+`domain/domain-errors.ts`, which **re-exports** the shared base and extends it:
+
+```typescript
+// src/modules/position/domain/domain-errors.ts
+export { DomainError, AuthorizationError, NotFoundError } from '../../../common/errors';
+import { DomainError } from '../../../common/errors';
+
+export class ChronologyError extends DomainError {}
+export class StateError extends DomainError {}
+export class InvariantError extends DomainError {}
+```
+
+So consumers always import from their own module path (`from '../domain/domain-errors'`),
+never reach across modules, yet every error shares one `DomainError` identity.
+
+### Error → HTTP mapping (the boundary)
+
+`DomainErrorFilter` (`src/common/filters/domain-error.filter.ts`, wired globally via
+`APP_FILTER` in `app.module.ts`) catches everything and maps by `instanceof`:
+`AuthorizationError` → 403, `NotFoundError` → 404, any other `DomainError` → 400,
+NestJS `HttpException`s pass through, anything else is rethrown → 500. Use cases just
+throw the right `DomainError` subtype; never touch HTTP status codes in a use case.
 
 ## Repository Interfaces (domain layer)
 
@@ -94,11 +122,36 @@ export class OpenPositionUseCase {
 - DTOs use value objects, not primitives
 - Write use cases return minimal data (just IDs)
 - Read use cases return full entities
-- Always check ownership on existing resources:
+- **Any use case that reads or mutates an *existing* resource takes `authContext` and
+  verifies ownership** — this is mandatory, not optional. The global `AuthGuard` only
+  proves the caller is logged in (authentication), never that they own the object
+  (authorization). Skipping the check is an IDOR. See the `backend-security` skill.
+
+Load the resource, then guard before doing anything with it:
 
 ```typescript
+const resource = await this.readRepo.findById(request.id);
+if (!resource) {
+  throw new NotFoundError(`Resource ${request.id.value} not found`);
+}
 if (resource.userId.value !== authContext.userId.value) {
-  throw new Error('User does not own this resource');
+  throw new AuthorizationError('User does not own this resource');
+}
+```
+
+**Child resources derive ownership from their parent.** If the entity has no `userId`
+of its own (e.g. `WatchlistMonitoring` belongs to a `Watchlist`), load the parent
+aggregate via its read repository and check the parent's `userId` — do **not** add a
+redundant `userId` to the child:
+
+```typescript
+// watchlist-monitoring use case: ownership comes from the parent watchlist
+const watchlist = await this.watchlistReadRepository.findById(request.watchlistId);
+if (!watchlist) {
+  throw new NotFoundError(`Watchlist ${request.watchlistId.value} not found`);
+}
+if (watchlist.userId.value !== authContext.userId.value) {
+  throw new AuthorizationError('User does not own this watchlist');
 }
 ```
 

--- a/.claude/skills/backend-security/SKILL.md
+++ b/.claude/skills/backend-security/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: backend-security
+description: Use when building or reviewing anything that touches the auth/ownership boundary in the Blue Star backend — controllers, use cases that read/mutate existing resources, new API endpoints, @Public() routes, or any handler that accepts a resource id from the client.
+---
+
+# Blue Star Backend Security
+
+The backend's authorization model is simple but easy to get wrong. This skill is the
+threat model and the non-negotiable rules. For the *mechanics* (which error to throw,
+how it maps to HTTP, where errors live) see the `backend-patterns` skill.
+
+## The one rule that matters: authentication ≠ authorization
+
+The global `AuthGuard` populates `req.user` and proves the caller is **logged in**. It
+proves **nothing** about whether they own the resource they're acting on. Ownership is a
+separate, explicit check that every use case must perform itself.
+
+> A logged-in user passing someone else's `watchlistId` / `positionId` is the default
+> attack. If a handler takes an id from the client and doesn't check ownership, it is an
+> IDOR (Insecure Direct Object Reference), full stop.
+
+This is not hypothetical: the `watchlist-monitoring` module shipped without this check —
+any authenticated user could activate/deactivate monitoring on, or read the status of,
+any watchlist by guessing an id. That's the bug this skill exists to prevent.
+
+## Rules
+
+1. **Every use case that reads or mutates an existing resource takes `authContext` and
+   verifies ownership.** No exceptions for "internal-looking" or read-only endpoints —
+   reading another user's data is still a breach. Construction-only use cases (create a
+   brand-new resource owned by the caller) don't need a lookup, but they must still set
+   ownership from `authContext`, never from the request body.
+
+2. **Trust ids from the client only after an ownership check.** A `watchlistId` /
+   `positionId` in a path param or body is attacker-controlled. Load the resource, then
+   compare `resource.userId.value === authContext.userId.value` before using it.
+
+3. **Child resources derive ownership from their parent aggregate.** Don't trust a child
+   id in isolation, and don't denormalize a `userId` onto the child to dodge the parent
+   lookup. Load the parent via its read repository and check the parent's owner. (See the
+   `backend-patterns` "Use Cases" section for the code.)
+
+4. **Reject with the typed error, not a bare `Error`.** `throw new AuthorizationError(...)`
+   → 403, `throw new NotFoundError(...)` → 404, via `DomainErrorFilter`. A bare `Error`
+   leaks as a 500 and tells the caller nothing — and historically these were written as
+   `throw new Error('User does not own this ...')`, which is the anti-pattern. Don't
+   reintroduce it.
+
+5. **Prefer "not found" semantics where leaking existence is itself a risk.** Returning
+   403 confirms the resource exists. For sensitive resources, returning 404 for both
+   "doesn't exist" and "exists but not yours" avoids that enumeration leak. Default to
+   403 for ownership (clearer), but make it a deliberate choice for sensitive data.
+
+6. **`@Public()` endpoints need a deliberate justification.** Anything marked `@Public()`
+   bypasses `AuthGuard` entirely. It must touch no user-owned data and, ideally, no
+   expensive/abusable operation. The `stock-analysis` `consolidations/run` and
+   `rs-ratings/run` POST endpoints are public and kick off expensive Python jobs — that's
+   a known, accepted trade-off, but new public endpoints must clear the same bar
+   explicitly, not by omission.
+
+7. **Order the guards: not-found before ownership.** Load → null check (`NotFoundError`)
+   → ownership check (`AuthorizationError`) → do the work. Never mutate, then check.
+
+8. **Parameterized SQL only.** All queries use `$1, $2` placeholders via `DatabaseService`
+   — never string-interpolate client input into SQL. (The codebase is clean here; keep it
+   that way.)
+
+## Controller responsibilities
+
+The controller builds `AuthContext` from `req.user` and passes it as the **second
+argument** to `useCase.execute(request, authContext)` — mirror the watchlist controller
+exactly. A handler that accepts a resource id but never reads `req.user` is the first
+red flag to look for in review.
+
+```typescript
+async activate(@Param('watchlistId') id: string, @Req() req: AuthenticatedRequest) {
+  const authContext: AuthContext = { userId: req.user.userId };
+  return this.activateMonitoringUseCase.execute(
+    { watchlistId: WatchlistId.of(id), /* ... */ },
+    authContext,
+  );
+}
+```
+
+## Review checklist (use when reviewing a controller/use-case diff)
+
+- [ ] Does every use case operating on an existing resource take `authContext`?
+- [ ] Is ownership checked before any read/return/mutation?
+- [ ] For child resources, is ownership derived from the parent aggregate?
+- [ ] Are rejections `AuthorizationError` / `NotFoundError`, not bare `Error`?
+- [ ] Does the controller pass `authContext` from `req.user` (not from the body)?
+- [ ] Any new `@Public()` endpoint — is it justified and free of user-owned data?
+- [ ] Is all SQL parameterized?

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -19,6 +19,7 @@ import { StockClassificationModule } from './modules/stock-classification/stock-
 import { AuthGuard } from './modules/auth/auth.guard';
 import { ScheduleModule } from '@nestjs/schedule';
 import { DatabaseModule } from './config/database.module';
+import { DomainErrorFilter } from './common/filters/domain-error.filter';
 
 @Module({
   imports: [
@@ -48,6 +49,10 @@ import { DatabaseModule } from './config/database.module';
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: DomainErrorFilter,
     },
   ],
 })

--- a/apps/backend/src/common/errors/domain-error.ts
+++ b/apps/backend/src/common/errors/domain-error.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared base for all domain errors and the two cross-cutting boundary errors.
+ *
+ * `DomainError` is the single base every module's error taxonomy extends, so the
+ * HTTP-boundary exception filter can recognise any domain error with a single
+ * `instanceof DomainError` (no string-name matching).
+ *
+ * `AuthorizationError` (403) and `NotFoundError` (404) live here rather than in a
+ * single domain module because they are *boundary* concerns shared across every
+ * bounded context. Module-specific errors (e.g. `StateError`, `InvariantError`,
+ * `ChronologyError`) stay in each module's `domain-errors.ts` and extend this base.
+ */
+export class DomainError extends Error {}
+
+/** Caller is authenticated but does not own / may not act on the resource → 403. */
+export class AuthorizationError extends DomainError {}
+
+/** Requested resource does not exist → 404. */
+export class NotFoundError extends DomainError {}

--- a/apps/backend/src/common/errors/index.ts
+++ b/apps/backend/src/common/errors/index.ts
@@ -1,0 +1,1 @@
+export { DomainError, AuthorizationError, NotFoundError } from './domain-error';

--- a/apps/backend/src/common/filters/domain-error.filter.ts
+++ b/apps/backend/src/common/filters/domain-error.filter.ts
@@ -1,0 +1,76 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { AuthorizationError, DomainError, NotFoundError } from '../errors';
+
+/**
+ * Maps domain errors to HTTP responses.
+ *
+ * Every module's error taxonomy extends the single shared `DomainError`
+ * (`src/common/errors`), so this filter recognises any domain error with a
+ * plain `instanceof` — no string-name matching. `AuthorizationError` → 403 and
+ * `NotFoundError` → 404 are the cross-cutting boundary errors; any other
+ * `DomainError` (StateError/InvariantError/ChronologyError/etc.) → 400.
+ *
+ * The response body matches NestJS's default HttpException JSON shape
+ * (`{ statusCode, message, error }`) so the frontend sees consistent errors.
+ */
+@Catch()
+export class DomainErrorFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    // Let NestJS-native HttpExceptions pass through with their own handling.
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const body = exception.getResponse();
+      response
+        .status(status)
+        .json(
+          typeof body === 'string'
+            ? { statusCode: status, message: body }
+            : body,
+        );
+      return;
+    }
+
+    const status = this.mapStatus(exception);
+
+    if (status === HttpStatus.INTERNAL_SERVER_ERROR) {
+      // Not a recognised domain error: rethrow so the default handler logs it.
+      throw exception;
+    }
+
+    const message =
+      exception instanceof Error ? exception.message : 'Bad Request';
+
+    response.status(status).json({
+      statusCode: status,
+      message,
+      error: HttpStatus[status]
+        .split('_')
+        .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+        .join(' '),
+    });
+  }
+
+  private mapStatus(exception: unknown): HttpStatus {
+    if (exception instanceof AuthorizationError) {
+      return HttpStatus.FORBIDDEN;
+    }
+    if (exception instanceof NotFoundError) {
+      return HttpStatus.NOT_FOUND;
+    }
+    if (exception instanceof DomainError) {
+      // Any other DomainError (StateError/InvariantError/ChronologyError/etc.)
+      return HttpStatus.BAD_REQUEST;
+    }
+    return HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+}

--- a/apps/backend/src/modules/leader-scan/domain/domain-errors.ts
+++ b/apps/backend/src/modules/leader-scan/domain/domain-errors.ts
@@ -1,3 +1,5 @@
-export class DomainError extends Error {}
+export { DomainError } from '../../../common/errors';
+import { DomainError } from '../../../common/errors';
+
 export class InvariantError extends DomainError {}
 export class StateError extends DomainError {}

--- a/apps/backend/src/modules/market-health/domain/domain-errors.ts
+++ b/apps/backend/src/modules/market-health/domain/domain-errors.ts
@@ -1,2 +1,4 @@
-export class DomainError extends Error {}
+export { DomainError } from '../../../common/errors';
+import { DomainError } from '../../../common/errors';
+
 export class InvariantError extends DomainError {}

--- a/apps/backend/src/modules/position/domain/domain-errors.ts
+++ b/apps/backend/src/modules/position/domain/domain-errors.ts
@@ -1,4 +1,10 @@
-export class DomainError extends Error {}
+export {
+  DomainError,
+  AuthorizationError,
+  NotFoundError,
+} from '../../../common/errors';
+import { DomainError } from '../../../common/errors';
+
 export class ChronologyError extends DomainError {}
 export class StateError extends DomainError {}
 export class InvariantError extends DomainError {}

--- a/apps/backend/src/modules/position/infrastructure/repositories/position-write.repository.ts
+++ b/apps/backend/src/modules/position/infrastructure/repositories/position-write.repository.ts
@@ -86,27 +86,17 @@ export class PositionWriteRepository implements IPositionWriteRepository {
         const stopPrice =
           event.action === Action.STOP_LOSS ? event.stop.value : null;
 
-        try {
-          await client.query(eventQuery, [
-            eventId,
-            position.id.value,
-            event.action,
-            event.ts.value,
-            event.instrument.value,
-            quantity,
-            price,
-            stopPrice,
-            event.note,
-          ]);
-        } catch (error) {
-          console.error('Error inserting event:', error);
-          console.error('Event data:', {
-            eventId,
-            positionId: position.id.value,
-            action: event.action,
-          });
-          throw error;
-        }
+        await client.query(eventQuery, [
+          eventId,
+          position.id.value,
+          event.action,
+          event.ts.value,
+          event.instrument.value,
+          quantity,
+          price,
+          stopPrice,
+          event.note,
+        ]);
       }
     });
   }

--- a/apps/backend/src/modules/position/use-cases/buy-shares.use-case.ts
+++ b/apps/backend/src/modules/position/use-cases/buy-shares.use-case.ts
@@ -6,6 +6,7 @@ import { IsoTimestamp } from '../domain/value-objects/iso-timestamp';
 import type { PositionWriteRepository } from '../domain/repositories/position-write.repository.interface';
 import type { AuthContext } from '../../auth/auth-context.interface';
 import { POSITION_WRITE_REPOSITORY } from '../constants/tokens';
+import { AuthorizationError } from '../domain/domain-errors';
 
 export interface BuySharesRequestDto {
   positionId: PositionId;
@@ -36,7 +37,7 @@ export class BuySharesUseCase {
     );
 
     if (position.userId.value !== authContext.userId.value) {
-      throw new Error('User does not own this position');
+      throw new AuthorizationError('User does not own this position');
     }
 
     position.buy({

--- a/apps/backend/src/modules/position/use-cases/get-position-by-id.use-case.ts
+++ b/apps/backend/src/modules/position/use-cases/get-position-by-id.use-case.ts
@@ -3,6 +3,7 @@ import { PositionId } from '../domain/value-objects/position-id';
 import { Position } from '../domain/entities/position';
 import { PositionReadRepository } from '../domain/repositories/position-read.repository.interface';
 import { POSITION_READ_REPOSITORY } from '../constants/tokens';
+import { AuthorizationError, NotFoundError } from '../domain/domain-errors';
 import type { AuthContext } from '../../auth/auth-context.interface';
 
 export interface GetPositionByIdRequestDto {
@@ -29,12 +30,14 @@ export class GetPositionByIdUseCase {
     );
 
     if (!position) {
-      throw new Error(`Position with ID ${request.positionId.value} not found`);
+      throw new NotFoundError(
+        `Position with ID ${request.positionId.value} not found`,
+      );
     }
 
     // Validate user owns the position
     if (position.userId.value !== authContext.userId.value) {
-      throw new Error('User does not own this position');
+      throw new AuthorizationError('User does not own this position');
     }
 
     return { position };

--- a/apps/backend/src/modules/position/use-cases/sell-shares.use-case.ts
+++ b/apps/backend/src/modules/position/use-cases/sell-shares.use-case.ts
@@ -6,6 +6,7 @@ import { IsoTimestamp } from '../domain/value-objects/iso-timestamp';
 import type { PositionWriteRepository } from '../domain/repositories/position-write.repository.interface';
 import type { AuthContext } from '../../auth/auth-context.interface';
 import { POSITION_WRITE_REPOSITORY } from '../constants/tokens';
+import { AuthorizationError } from '../domain/domain-errors';
 
 export interface SellSharesRequestDto {
   positionId: PositionId;
@@ -37,7 +38,7 @@ export class SellSharesUseCase {
     );
 
     if (position.userId.value !== authContext.userId.value) {
-      throw new Error('User does not own this position');
+      throw new AuthorizationError('User does not own this position');
     }
 
     position.sell({

--- a/apps/backend/src/modules/position/use-cases/set-stop-loss.use-case.ts
+++ b/apps/backend/src/modules/position/use-cases/set-stop-loss.use-case.ts
@@ -5,6 +5,7 @@ import { IsoTimestamp } from '../domain/value-objects/iso-timestamp';
 import type { PositionWriteRepository } from '../domain/repositories/position-write.repository.interface';
 import type { AuthContext } from '../../auth/auth-context.interface';
 import { POSITION_WRITE_REPOSITORY } from '../constants/tokens';
+import { AuthorizationError } from '../domain/domain-errors';
 
 export interface SetStopLossRequestDto {
   positionId: PositionId;
@@ -33,7 +34,7 @@ export class SetStopLossUseCase {
     );
 
     if (position.userId.value !== authContext.userId.value) {
-      throw new Error('User does not own this position');
+      throw new AuthorizationError('User does not own this position');
     }
 
     position.setStop({

--- a/apps/backend/src/modules/sector-rotation/infrastructure/services/sector-rotation-cron.service.ts
+++ b/apps/backend/src/modules/sector-rotation/infrastructure/services/sector-rotation-cron.service.ts
@@ -3,6 +3,7 @@ import { Cron } from '@nestjs/schedule';
 import { SectorRotationPersistenceService } from '../../domain/services/sector-rotation-persistence.service';
 import { SECTOR_ROTATION_PERSISTENCE_SERVICE } from '../../constants/tokens';
 import { RotationUniverseRegistry } from '../universes/rotation-universe.registry';
+import { CronJobNotificationService } from '../../../notification/infrastructure/services/cron-job-notification.service';
 
 @Injectable()
 export class SectorRotationCronService {
@@ -12,28 +13,66 @@ export class SectorRotationCronService {
     @Inject(SECTOR_ROTATION_PERSISTENCE_SERVICE)
     private readonly persistenceService: SectorRotationPersistenceService,
     private readonly universeRegistry: RotationUniverseRegistry,
+    private readonly cronJobNotificationService: CronJobNotificationService,
   ) {}
 
   @Cron('30 16 * * 5', { timeZone: 'America/Toronto' })
   async runWeeklyCalculation() {
+    const jobName = 'Weekly Sector Rotation';
     const universes = this.universeRegistry.listUniverses();
     this.logger.log(
       `Starting weekly sector rotation calculation for ${universes.length} universe(s)...`,
     );
 
-    for (const universe of universes) {
-      try {
-        await this.persistenceService.computeAndSaveIncremental(universe);
-        this.logger.log(
-          `Weekly sector rotation calculation completed for universe ${universe.id}`,
-        );
-      } catch (error) {
-        const errorMessage = `Weekly sector rotation calculation failed for universe ${universe.id}: ${error instanceof Error ? error.message : 'Unknown error'}`;
-        this.logger.error(errorMessage);
-        if (error instanceof Error) {
-          this.logger.error(error.stack);
+    await this.cronJobNotificationService.notifyJobStart({
+      jobName,
+      jobType: 'sector-rotation',
+      frequency: 'weekly',
+    });
+
+    let succeeded = 0;
+    const failures: string[] = [];
+
+    try {
+      for (const universe of universes) {
+        try {
+          await this.persistenceService.computeAndSaveIncremental(universe);
+          succeeded += 1;
+          this.logger.log(
+            `Weekly sector rotation calculation completed for universe ${universe.id}`,
+          );
+        } catch (error) {
+          failures.push(universe.id);
+          const errorMessage = `Weekly sector rotation calculation failed for universe ${universe.id}: ${error instanceof Error ? error.message : 'Unknown error'}`;
+          this.logger.error(errorMessage);
+          if (error instanceof Error) {
+            this.logger.error(error.stack);
+          }
         }
       }
+
+      if (failures.length > 0) {
+        const errorMessage = `${failures.length}/${universes.length} universe(s) failed: ${failures.join(', ')}`;
+        await this.cronJobNotificationService.notifyJobError(
+          { jobName, jobType: 'sector-rotation', frequency: 'weekly' },
+          new Error(errorMessage),
+        );
+        return;
+      }
+
+      await this.cronJobNotificationService.notifyJobSuccess({
+        jobName,
+        jobType: 'sector-rotation',
+        frequency: 'weekly',
+        additionalData: `${succeeded}/${universes.length} universe(s) processed`,
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`${jobName} failed: ${msg}`);
+      await this.cronJobNotificationService.notifyJobError(
+        { jobName, jobType: 'sector-rotation', frequency: 'weekly' },
+        error,
+      );
     }
   }
 }

--- a/apps/backend/src/modules/sector-rotation/sector-rotation.module.ts
+++ b/apps/backend/src/modules/sector-rotation/sector-rotation.module.ts
@@ -22,6 +22,7 @@ import {
   SECTOR_ROTATION_PERSISTENCE_SERVICE,
 } from './constants/tokens';
 import { MarketDataModule } from '../market-data/market-data.module';
+import { NotificationModule } from '../notification/notification.module';
 
 export {
   SECTOR_ROTATION_CALCULATION_SERVICE,
@@ -32,7 +33,7 @@ export {
 };
 
 @Module({
-  imports: [DatabaseModule, MarketDataModule],
+  imports: [DatabaseModule, MarketDataModule, NotificationModule],
   controllers: [SectorRotationController],
   providers: [
     {

--- a/apps/backend/src/modules/watchlist-monitoring/api/watchlist-monitoring.controller.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/api/watchlist-monitoring.controller.ts
@@ -1,9 +1,11 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Req } from '@nestjs/common';
 import { WatchlistId } from '../../watchlist/domain/value-objects/watchlist-id';
 import {
   MonitoringType,
   isValidMonitoringType,
 } from '../domain/value-objects/monitoring-type';
+import type { AuthContext } from '../../auth/auth-context.interface';
+import type { AuthenticatedRequest } from '../../auth/types/request.interface';
 import { WatchlistMonitoringApiMapper } from './watchlist-monitoring-api.mapper';
 import {
   ActivateMonitoringApiResponseDto,
@@ -35,13 +37,21 @@ export class WatchlistMonitoringController {
   @Get(':watchlistId')
   async getMonitoringStatus(
     @Param('watchlistId') watchlistId: string,
+    @Req() req: AuthenticatedRequest,
   ): Promise<GetMonitoringStatusApiResponseDto> {
+    const user = req.user;
+    const authContext: AuthContext = {
+      userId: user.userId,
+    };
+
     const request: GetMonitoringStatusRequestDto = {
       watchlistId: WatchlistId.of(watchlistId),
     };
 
-    const useCaseResponse =
-      await this.getMonitoringStatusUseCase.execute(request);
+    const useCaseResponse = await this.getMonitoringStatusUseCase.execute(
+      request,
+      authContext,
+    );
     return this.watchlistMonitoringApiMapper.mapGetMonitoringStatusResponse(
       useCaseResponse,
     );
@@ -51,18 +61,26 @@ export class WatchlistMonitoringController {
   async activateMonitoring(
     @Param('watchlistId') watchlistId: string,
     @Body() body: { type: string },
+    @Req() req: AuthenticatedRequest,
   ): Promise<ActivateMonitoringApiResponseDto> {
     if (!isValidMonitoringType(body.type)) {
       throw new Error(`Invalid monitoring type: ${body.type}`);
     }
+
+    const user = req.user;
+    const authContext: AuthContext = {
+      userId: user.userId,
+    };
 
     const request: ActivateMonitoringRequestDto = {
       watchlistId: WatchlistId.of(watchlistId),
       type: body.type as MonitoringType,
     };
 
-    const useCaseResponse =
-      await this.activateMonitoringUseCase.execute(request);
+    const useCaseResponse = await this.activateMonitoringUseCase.execute(
+      request,
+      authContext,
+    );
     return this.watchlistMonitoringApiMapper.mapActivateMonitoringResponse(
       useCaseResponse,
     );
@@ -72,18 +90,26 @@ export class WatchlistMonitoringController {
   async deactivateMonitoring(
     @Param('watchlistId') watchlistId: string,
     @Body() body: { type: string },
+    @Req() req: AuthenticatedRequest,
   ): Promise<DeactivateMonitoringApiResponseDto> {
     if (!isValidMonitoringType(body.type)) {
       throw new Error(`Invalid monitoring type: ${body.type}`);
     }
+
+    const user = req.user;
+    const authContext: AuthContext = {
+      userId: user.userId,
+    };
 
     const request: DeactivateMonitoringRequestDto = {
       watchlistId: WatchlistId.of(watchlistId),
       type: body.type as MonitoringType,
     };
 
-    const useCaseResponse =
-      await this.deactivateMonitoringUseCase.execute(request);
+    const useCaseResponse = await this.deactivateMonitoringUseCase.execute(
+      request,
+      authContext,
+    );
     return this.watchlistMonitoringApiMapper.mapDeactivateMonitoringResponse(
       useCaseResponse,
     );

--- a/apps/backend/src/modules/watchlist-monitoring/domain/domain-errors.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/domain/domain-errors.ts
@@ -1,3 +1,9 @@
-export class DomainError extends Error {}
+export {
+  DomainError,
+  AuthorizationError,
+  NotFoundError,
+} from '../../../common/errors';
+import { DomainError } from '../../../common/errors';
+
 export class StateError extends DomainError {}
 export class InvariantError extends DomainError {}

--- a/apps/backend/src/modules/watchlist-monitoring/use-cases/activate-monitoring.use-case.spec.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/use-cases/activate-monitoring.use-case.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  ActivateMonitoringRequestDto,
+  ActivateMonitoringUseCase,
+} from './activate-monitoring.use-case';
+import { WatchlistMonitoringWriteRepository } from '../domain/repositories/watchlist-monitoring-write.repository.interface';
+import { WatchlistReadRepository } from '../../watchlist/domain/repositories/watchlist-read.repository.interface';
+import { WATCHLIST_MONITORING_WRITE_REPOSITORY } from '../constants/tokens';
+import { WATCHLIST_READ_REPOSITORY } from '../../watchlist/constants/tokens';
+import { WatchlistMonitoring } from '../domain/entities/watchlist-monitoring.entity';
+import { WatchlistMonitoringId } from '../domain/value-objects/watchlist-monitoring-id';
+import { MonitoringType } from '../domain/value-objects/monitoring-type';
+import { Watchlist } from '../../watchlist/domain/entities/watchlist';
+import { WatchlistName } from '../../watchlist/domain/value-objects/watchlist-name';
+import { WatchlistId } from '../../watchlist/domain/value-objects/watchlist-id';
+import { UserId } from '../../../modules/position/domain/value-objects/user-id';
+import { AuthorizationError, NotFoundError } from '../domain/domain-errors';
+import type { AuthContext } from '../../auth/auth-context.interface';
+
+describe('ActivateMonitoringUseCase', () => {
+  let useCase: ActivateMonitoringUseCase;
+  let mockMonitoringWriteRepository: jest.Mocked<WatchlistMonitoringWriteRepository>;
+  let mockWatchlistReadRepository: jest.Mocked<WatchlistReadRepository>;
+
+  const userId = UserId.of('user-123');
+  const watchlistId = WatchlistId.of('11111111-1111-1111-1111-111111111111');
+  const authContext: AuthContext = { userId };
+
+  const request: ActivateMonitoringRequestDto = {
+    watchlistId,
+    type: MonitoringType.BREAKOUT,
+  };
+
+  const ownedWatchlist = (ownerId: UserId = userId): Watchlist =>
+    Watchlist.fromData({
+      id: watchlistId,
+      userId: ownerId,
+      name: WatchlistName.of('My Watchlist'),
+      tickers: [],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+  beforeEach(async () => {
+    mockMonitoringWriteRepository = {
+      save: jest.fn().mockResolvedValue(undefined),
+      findByWatchlistIdAndType: jest.fn(),
+    };
+
+    mockWatchlistReadRepository = {
+      findById: jest.fn(),
+      findByUserId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ActivateMonitoringUseCase,
+        {
+          provide: WATCHLIST_MONITORING_WRITE_REPOSITORY,
+          useValue: mockMonitoringWriteRepository,
+        },
+        {
+          provide: WATCHLIST_READ_REPOSITORY,
+          useValue: mockWatchlistReadRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<ActivateMonitoringUseCase>(ActivateMonitoringUseCase);
+  });
+
+  describe('execute', () => {
+    it('should reactivate and save the existing monitoring when one is found', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(ownedWatchlist());
+      const existing = WatchlistMonitoring.fromData({
+        id: WatchlistMonitoringId.of('22222222-2222-2222-2222-222222222222'),
+        watchlistId,
+        type: MonitoringType.BREAKOUT,
+        active: false,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      });
+      mockMonitoringWriteRepository.findByWatchlistIdAndType.mockResolvedValue(
+        existing,
+      );
+
+      const result = await useCase.execute(request, authContext);
+
+      expect(
+        mockMonitoringWriteRepository.findByWatchlistIdAndType,
+      ).toHaveBeenCalledWith(watchlistId, MonitoringType.BREAKOUT);
+      expect(mockMonitoringWriteRepository.save).toHaveBeenCalledWith(existing);
+      expect(existing.active).toBe(true);
+      expect(result).toEqual({
+        monitoringId: existing.id,
+        active: true,
+      });
+    });
+
+    it('should create and save a new monitoring when none exists', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(ownedWatchlist());
+      mockMonitoringWriteRepository.findByWatchlistIdAndType.mockResolvedValue(
+        null,
+      );
+
+      const result = await useCase.execute(request, authContext);
+
+      expect(mockMonitoringWriteRepository.save).toHaveBeenCalledTimes(1);
+      const saved = mockMonitoringWriteRepository.save.mock.calls[0][0];
+      expect(saved.watchlistId).toEqual(watchlistId);
+      expect(saved.type).toBe(MonitoringType.BREAKOUT);
+      expect(saved.active).toBe(true);
+      expect(result).toEqual({
+        monitoringId: saved.id,
+        active: true,
+      });
+    });
+
+    it('should throw NotFoundError when the watchlist does not exist', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(null);
+
+      await expect(useCase.execute(request, authContext)).rejects.toThrow(
+        NotFoundError,
+      );
+      expect(
+        mockMonitoringWriteRepository.findByWatchlistIdAndType,
+      ).not.toHaveBeenCalled();
+      expect(mockMonitoringWriteRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw AuthorizationError when the watchlist belongs to another user', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(
+        ownedWatchlist(UserId.of('other-user')),
+      );
+
+      await expect(useCase.execute(request, authContext)).rejects.toThrow(
+        AuthorizationError,
+      );
+      expect(
+        mockMonitoringWriteRepository.findByWatchlistIdAndType,
+      ).not.toHaveBeenCalled();
+      expect(mockMonitoringWriteRepository.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/modules/watchlist-monitoring/use-cases/activate-monitoring.use-case.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/use-cases/activate-monitoring.use-case.ts
@@ -5,6 +5,10 @@ import { MonitoringType } from '../domain/value-objects/monitoring-type';
 import { WatchlistMonitoringId } from '../domain/value-objects/watchlist-monitoring-id';
 import type { WatchlistMonitoringWriteRepository } from '../domain/repositories/watchlist-monitoring-write.repository.interface';
 import { WATCHLIST_MONITORING_WRITE_REPOSITORY } from '../constants/tokens';
+import type { WatchlistReadRepository } from '../../watchlist/domain/repositories/watchlist-read.repository.interface';
+import { WATCHLIST_READ_REPOSITORY } from '../../watchlist/constants/tokens';
+import type { AuthContext } from '../../auth/auth-context.interface';
+import { AuthorizationError, NotFoundError } from '../domain/domain-errors';
 
 export interface ActivateMonitoringRequestDto {
   watchlistId: WatchlistId;
@@ -21,11 +25,28 @@ export class ActivateMonitoringUseCase {
   constructor(
     @Inject(WATCHLIST_MONITORING_WRITE_REPOSITORY)
     private readonly monitoringWriteRepository: WatchlistMonitoringWriteRepository,
+    @Inject(WATCHLIST_READ_REPOSITORY)
+    private readonly watchlistReadRepository: WatchlistReadRepository,
   ) {}
 
   async execute(
     request: ActivateMonitoringRequestDto,
+    authContext: AuthContext,
   ): Promise<ActivateMonitoringResponseDto> {
+    const watchlist = await this.watchlistReadRepository.findById(
+      request.watchlistId,
+    );
+
+    if (!watchlist) {
+      throw new NotFoundError(
+        `Watchlist with ID ${request.watchlistId.value} not found`,
+      );
+    }
+
+    if (watchlist.userId.value !== authContext.userId.value) {
+      throw new AuthorizationError('User does not own this watchlist');
+    }
+
     const existing =
       await this.monitoringWriteRepository.findByWatchlistIdAndType(
         request.watchlistId,

--- a/apps/backend/src/modules/watchlist-monitoring/use-cases/deactivate-monitoring.use-case.spec.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/use-cases/deactivate-monitoring.use-case.spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  DeactivateMonitoringRequestDto,
+  DeactivateMonitoringUseCase,
+} from './deactivate-monitoring.use-case';
+import { WatchlistMonitoringWriteRepository } from '../domain/repositories/watchlist-monitoring-write.repository.interface';
+import { WatchlistReadRepository } from '../../watchlist/domain/repositories/watchlist-read.repository.interface';
+import { WATCHLIST_MONITORING_WRITE_REPOSITORY } from '../constants/tokens';
+import { WATCHLIST_READ_REPOSITORY } from '../../watchlist/constants/tokens';
+import { WatchlistMonitoring } from '../domain/entities/watchlist-monitoring.entity';
+import { WatchlistMonitoringId } from '../domain/value-objects/watchlist-monitoring-id';
+import { MonitoringType } from '../domain/value-objects/monitoring-type';
+import { Watchlist } from '../../watchlist/domain/entities/watchlist';
+import { WatchlistName } from '../../watchlist/domain/value-objects/watchlist-name';
+import { WatchlistId } from '../../watchlist/domain/value-objects/watchlist-id';
+import { UserId } from '../../../modules/position/domain/value-objects/user-id';
+import { AuthorizationError, NotFoundError } from '../domain/domain-errors';
+import type { AuthContext } from '../../auth/auth-context.interface';
+
+describe('DeactivateMonitoringUseCase', () => {
+  let useCase: DeactivateMonitoringUseCase;
+  let mockMonitoringWriteRepository: jest.Mocked<WatchlistMonitoringWriteRepository>;
+  let mockWatchlistReadRepository: jest.Mocked<WatchlistReadRepository>;
+
+  const userId = UserId.of('user-123');
+  const watchlistId = WatchlistId.of('11111111-1111-1111-1111-111111111111');
+  const authContext: AuthContext = { userId };
+
+  const request: DeactivateMonitoringRequestDto = {
+    watchlistId,
+    type: MonitoringType.BREAKOUT,
+  };
+
+  const ownedWatchlist = (ownerId: UserId = userId): Watchlist =>
+    Watchlist.fromData({
+      id: watchlistId,
+      userId: ownerId,
+      name: WatchlistName.of('My Watchlist'),
+      tickers: [],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+  beforeEach(async () => {
+    mockMonitoringWriteRepository = {
+      save: jest.fn().mockResolvedValue(undefined),
+      findByWatchlistIdAndType: jest.fn(),
+    };
+
+    mockWatchlistReadRepository = {
+      findById: jest.fn(),
+      findByUserId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeactivateMonitoringUseCase,
+        {
+          provide: WATCHLIST_MONITORING_WRITE_REPOSITORY,
+          useValue: mockMonitoringWriteRepository,
+        },
+        {
+          provide: WATCHLIST_READ_REPOSITORY,
+          useValue: mockWatchlistReadRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<DeactivateMonitoringUseCase>(
+      DeactivateMonitoringUseCase,
+    );
+  });
+
+  describe('execute', () => {
+    it('should deactivate and save the monitoring when it exists', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(ownedWatchlist());
+      const existing = WatchlistMonitoring.fromData({
+        id: WatchlistMonitoringId.of('22222222-2222-2222-2222-222222222222'),
+        watchlistId,
+        type: MonitoringType.BREAKOUT,
+        active: true,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      });
+      mockMonitoringWriteRepository.findByWatchlistIdAndType.mockResolvedValue(
+        existing,
+      );
+
+      const result = await useCase.execute(request, authContext);
+
+      expect(
+        mockMonitoringWriteRepository.findByWatchlistIdAndType,
+      ).toHaveBeenCalledWith(watchlistId, MonitoringType.BREAKOUT);
+      expect(mockMonitoringWriteRepository.save).toHaveBeenCalledWith(existing);
+      expect(existing.active).toBe(false);
+      expect(result).toEqual({ active: false });
+    });
+
+    it('should throw NotFoundError when no monitoring exists for the watchlist', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(ownedWatchlist());
+      mockMonitoringWriteRepository.findByWatchlistIdAndType.mockResolvedValue(
+        null,
+      );
+
+      await expect(useCase.execute(request, authContext)).rejects.toThrow(
+        NotFoundError,
+      );
+      expect(mockMonitoringWriteRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundError when the watchlist does not exist', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(null);
+
+      await expect(useCase.execute(request, authContext)).rejects.toThrow(
+        NotFoundError,
+      );
+      expect(
+        mockMonitoringWriteRepository.findByWatchlistIdAndType,
+      ).not.toHaveBeenCalled();
+      expect(mockMonitoringWriteRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should throw AuthorizationError when the watchlist belongs to another user', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(
+        ownedWatchlist(UserId.of('other-user')),
+      );
+
+      await expect(useCase.execute(request, authContext)).rejects.toThrow(
+        AuthorizationError,
+      );
+      expect(
+        mockMonitoringWriteRepository.findByWatchlistIdAndType,
+      ).not.toHaveBeenCalled();
+      expect(mockMonitoringWriteRepository.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/modules/watchlist-monitoring/use-cases/deactivate-monitoring.use-case.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/use-cases/deactivate-monitoring.use-case.ts
@@ -3,6 +3,10 @@ import { WatchlistId } from '../../watchlist/domain/value-objects/watchlist-id';
 import { MonitoringType } from '../domain/value-objects/monitoring-type';
 import type { WatchlistMonitoringWriteRepository } from '../domain/repositories/watchlist-monitoring-write.repository.interface';
 import { WATCHLIST_MONITORING_WRITE_REPOSITORY } from '../constants/tokens';
+import type { WatchlistReadRepository } from '../../watchlist/domain/repositories/watchlist-read.repository.interface';
+import { WATCHLIST_READ_REPOSITORY } from '../../watchlist/constants/tokens';
+import type { AuthContext } from '../../auth/auth-context.interface';
+import { AuthorizationError, NotFoundError } from '../domain/domain-errors';
 
 export interface DeactivateMonitoringRequestDto {
   watchlistId: WatchlistId;
@@ -18,11 +22,28 @@ export class DeactivateMonitoringUseCase {
   constructor(
     @Inject(WATCHLIST_MONITORING_WRITE_REPOSITORY)
     private readonly monitoringWriteRepository: WatchlistMonitoringWriteRepository,
+    @Inject(WATCHLIST_READ_REPOSITORY)
+    private readonly watchlistReadRepository: WatchlistReadRepository,
   ) {}
 
   async execute(
     request: DeactivateMonitoringRequestDto,
+    authContext: AuthContext,
   ): Promise<DeactivateMonitoringResponseDto> {
+    const watchlist = await this.watchlistReadRepository.findById(
+      request.watchlistId,
+    );
+
+    if (!watchlist) {
+      throw new NotFoundError(
+        `Watchlist with ID ${request.watchlistId.value} not found`,
+      );
+    }
+
+    if (watchlist.userId.value !== authContext.userId.value) {
+      throw new AuthorizationError('User does not own this watchlist');
+    }
+
     const monitoring =
       await this.monitoringWriteRepository.findByWatchlistIdAndType(
         request.watchlistId,
@@ -30,7 +51,7 @@ export class DeactivateMonitoringUseCase {
       );
 
     if (!monitoring) {
-      throw new Error(
+      throw new NotFoundError(
         `No ${request.type} monitoring found for watchlist ${request.watchlistId.value}`,
       );
     }

--- a/apps/backend/src/modules/watchlist-monitoring/use-cases/get-monitoring-status.use-case.spec.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/use-cases/get-monitoring-status.use-case.spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  GetMonitoringStatusRequestDto,
+  GetMonitoringStatusUseCase,
+} from './get-monitoring-status.use-case';
+import { WatchlistMonitoringReadRepository } from '../domain/repositories/watchlist-monitoring-read.repository.interface';
+import { WatchlistReadRepository } from '../../watchlist/domain/repositories/watchlist-read.repository.interface';
+import { WATCHLIST_MONITORING_READ_REPOSITORY } from '../constants/tokens';
+import { WATCHLIST_READ_REPOSITORY } from '../../watchlist/constants/tokens';
+import { WatchlistMonitoring } from '../domain/entities/watchlist-monitoring.entity';
+import { WatchlistMonitoringId } from '../domain/value-objects/watchlist-monitoring-id';
+import { MonitoringType } from '../domain/value-objects/monitoring-type';
+import { Watchlist } from '../../watchlist/domain/entities/watchlist';
+import { WatchlistName } from '../../watchlist/domain/value-objects/watchlist-name';
+import { WatchlistId } from '../../watchlist/domain/value-objects/watchlist-id';
+import { UserId } from '../../../modules/position/domain/value-objects/user-id';
+import { AuthorizationError, NotFoundError } from '../domain/domain-errors';
+import type { AuthContext } from '../../auth/auth-context.interface';
+
+describe('GetMonitoringStatusUseCase', () => {
+  let useCase: GetMonitoringStatusUseCase;
+  let mockMonitoringReadRepository: jest.Mocked<WatchlistMonitoringReadRepository>;
+  let mockWatchlistReadRepository: jest.Mocked<WatchlistReadRepository>;
+
+  const userId = UserId.of('user-123');
+  const watchlistId = WatchlistId.of('11111111-1111-1111-1111-111111111111');
+  const authContext: AuthContext = { userId };
+
+  const request: GetMonitoringStatusRequestDto = { watchlistId };
+
+  const ownedWatchlist = (ownerId: UserId = userId): Watchlist =>
+    Watchlist.fromData({
+      id: watchlistId,
+      userId: ownerId,
+      name: WatchlistName.of('My Watchlist'),
+      tickers: [],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+  beforeEach(async () => {
+    mockMonitoringReadRepository = {
+      findByWatchlistId: jest.fn(),
+      findByWatchlistIdAndType: jest.fn(),
+      findAllActive: jest.fn(),
+      findAllActiveByType: jest.fn(),
+    };
+
+    mockWatchlistReadRepository = {
+      findById: jest.fn(),
+      findByUserId: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GetMonitoringStatusUseCase,
+        {
+          provide: WATCHLIST_MONITORING_READ_REPOSITORY,
+          useValue: mockMonitoringReadRepository,
+        },
+        {
+          provide: WATCHLIST_READ_REPOSITORY,
+          useValue: mockWatchlistReadRepository,
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<GetMonitoringStatusUseCase>(
+      GetMonitoringStatusUseCase,
+    );
+  });
+
+  describe('execute', () => {
+    it('should return the mapped monitoring statuses for the watchlist', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(ownedWatchlist());
+      const monitoring = WatchlistMonitoring.fromData({
+        id: WatchlistMonitoringId.of('22222222-2222-2222-2222-222222222222'),
+        watchlistId,
+        type: MonitoringType.BREAKOUT,
+        active: true,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      });
+      mockMonitoringReadRepository.findByWatchlistId.mockResolvedValue([
+        monitoring,
+      ]);
+
+      const result = await useCase.execute(request, authContext);
+
+      expect(
+        mockMonitoringReadRepository.findByWatchlistId,
+      ).toHaveBeenCalledWith(watchlistId);
+      expect(result).toEqual({
+        monitorings: [
+          {
+            watchlistId: watchlistId.value,
+            type: MonitoringType.BREAKOUT,
+            active: true,
+          },
+        ],
+      });
+    });
+
+    it('should return an empty list when the watchlist has no monitorings', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(ownedWatchlist());
+      mockMonitoringReadRepository.findByWatchlistId.mockResolvedValue([]);
+
+      const result = await useCase.execute(request, authContext);
+
+      expect(result).toEqual({ monitorings: [] });
+    });
+
+    it('should throw NotFoundError when the watchlist does not exist', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(null);
+
+      await expect(useCase.execute(request, authContext)).rejects.toThrow(
+        NotFoundError,
+      );
+      expect(
+        mockMonitoringReadRepository.findByWatchlistId,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should throw AuthorizationError when the watchlist belongs to another user', async () => {
+      mockWatchlistReadRepository.findById.mockResolvedValue(
+        ownedWatchlist(UserId.of('other-user')),
+      );
+
+      await expect(useCase.execute(request, authContext)).rejects.toThrow(
+        AuthorizationError,
+      );
+      expect(
+        mockMonitoringReadRepository.findByWatchlistId,
+      ).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/modules/watchlist-monitoring/use-cases/get-monitoring-status.use-case.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/use-cases/get-monitoring-status.use-case.ts
@@ -3,6 +3,10 @@ import { WatchlistId } from '../../watchlist/domain/value-objects/watchlist-id';
 import { MonitoringType } from '../domain/value-objects/monitoring-type';
 import type { WatchlistMonitoringReadRepository } from '../domain/repositories/watchlist-monitoring-read.repository.interface';
 import { WATCHLIST_MONITORING_READ_REPOSITORY } from '../constants/tokens';
+import type { WatchlistReadRepository } from '../../watchlist/domain/repositories/watchlist-read.repository.interface';
+import { WATCHLIST_READ_REPOSITORY } from '../../watchlist/constants/tokens';
+import type { AuthContext } from '../../auth/auth-context.interface';
+import { AuthorizationError, NotFoundError } from '../domain/domain-errors';
 
 export interface MonitoringStatusDto {
   watchlistId: string;
@@ -23,11 +27,28 @@ export class GetMonitoringStatusUseCase {
   constructor(
     @Inject(WATCHLIST_MONITORING_READ_REPOSITORY)
     private readonly monitoringReadRepository: WatchlistMonitoringReadRepository,
+    @Inject(WATCHLIST_READ_REPOSITORY)
+    private readonly watchlistReadRepository: WatchlistReadRepository,
   ) {}
 
   async execute(
     request: GetMonitoringStatusRequestDto,
+    authContext: AuthContext,
   ): Promise<GetMonitoringStatusResponseDto> {
+    const watchlist = await this.watchlistReadRepository.findById(
+      request.watchlistId,
+    );
+
+    if (!watchlist) {
+      throw new NotFoundError(
+        `Watchlist with ID ${request.watchlistId.value} not found`,
+      );
+    }
+
+    if (watchlist.userId.value !== authContext.userId.value) {
+      throw new AuthorizationError('User does not own this watchlist');
+    }
+
     const monitorings = await this.monitoringReadRepository.findByWatchlistId(
       request.watchlistId,
     );

--- a/apps/backend/src/modules/watchlist/domain/domain-errors.ts
+++ b/apps/backend/src/modules/watchlist/domain/domain-errors.ts
@@ -1,3 +1,9 @@
-export class DomainError extends Error {}
+export {
+  DomainError,
+  AuthorizationError,
+  NotFoundError,
+} from '../../../common/errors';
+import { DomainError } from '../../../common/errors';
+
 export class StateError extends DomainError {}
 export class InvariantError extends DomainError {}

--- a/apps/backend/src/modules/watchlist/use-cases/add-ticker-to-watchlist.use-case.ts
+++ b/apps/backend/src/modules/watchlist/use-cases/add-ticker-to-watchlist.use-case.ts
@@ -5,6 +5,7 @@ import { WatchlistTicker } from '../domain/value-objects/watchlist-ticker';
 import type { WatchlistWriteRepository } from '../domain/repositories/watchlist-write.repository.interface';
 import type { AuthContext } from '../../auth/auth-context.interface';
 import { WATCHLIST_WRITE_REPOSITORY } from '../constants/tokens';
+import { AuthorizationError } from '../domain/domain-errors';
 
 export interface AddTickerToWatchlistRequestDto {
   watchlistId: WatchlistId;
@@ -31,7 +32,7 @@ export class AddTickerToWatchlistUseCase {
     );
 
     if (watchlist.userId.value !== authContext.userId.value) {
-      throw new Error('User does not own this watchlist');
+      throw new AuthorizationError('User does not own this watchlist');
     }
 
     watchlist.addTicker(request.ticker);

--- a/apps/backend/src/modules/watchlist/use-cases/delete-watchlist.use-case.ts
+++ b/apps/backend/src/modules/watchlist/use-cases/delete-watchlist.use-case.ts
@@ -3,6 +3,7 @@ import { WatchlistId } from '../domain/value-objects/watchlist-id';
 import type { WatchlistWriteRepository } from '../domain/repositories/watchlist-write.repository.interface';
 import type { AuthContext } from '../../auth/auth-context.interface';
 import { WATCHLIST_WRITE_REPOSITORY } from '../constants/tokens';
+import { AuthorizationError } from '../domain/domain-errors';
 
 export interface DeleteWatchlistRequestDto {
   watchlistId: WatchlistId;
@@ -28,7 +29,7 @@ export class DeleteWatchlistUseCase {
     );
 
     if (watchlist.userId.value !== authContext.userId.value) {
-      throw new Error('User does not own this watchlist');
+      throw new AuthorizationError('User does not own this watchlist');
     }
 
     await this.watchlistWriteRepository.delete(request.watchlistId);

--- a/apps/backend/src/modules/watchlist/use-cases/get-watchlist-by-id.use-case.ts
+++ b/apps/backend/src/modules/watchlist/use-cases/get-watchlist-by-id.use-case.ts
@@ -4,6 +4,7 @@ import { WatchlistId } from '../domain/value-objects/watchlist-id';
 import type { WatchlistReadRepository } from '../domain/repositories/watchlist-read.repository.interface';
 import type { AuthContext } from '../../auth/auth-context.interface';
 import { WATCHLIST_READ_REPOSITORY } from '../constants/tokens';
+import { AuthorizationError, NotFoundError } from '../domain/domain-errors';
 
 export interface GetWatchlistByIdRequestDto {
   watchlistId: WatchlistId;
@@ -29,13 +30,13 @@ export class GetWatchlistByIdUseCase {
     );
 
     if (!watchlist) {
-      throw new Error(
+      throw new NotFoundError(
         `Watchlist with ID ${request.watchlistId.value} not found`,
       );
     }
 
     if (watchlist.userId.value !== authContext.userId.value) {
-      throw new Error('User does not own this watchlist');
+      throw new AuthorizationError('User does not own this watchlist');
     }
 
     return {

--- a/apps/backend/src/modules/watchlist/use-cases/remove-ticker-from-watchlist.use-case.ts
+++ b/apps/backend/src/modules/watchlist/use-cases/remove-ticker-from-watchlist.use-case.ts
@@ -5,6 +5,7 @@ import { WatchlistTicker } from '../domain/value-objects/watchlist-ticker';
 import type { WatchlistWriteRepository } from '../domain/repositories/watchlist-write.repository.interface';
 import type { AuthContext } from '../../auth/auth-context.interface';
 import { WATCHLIST_WRITE_REPOSITORY } from '../constants/tokens';
+import { AuthorizationError } from '../domain/domain-errors';
 
 export interface RemoveTickerFromWatchlistRequestDto {
   watchlistId: WatchlistId;
@@ -31,7 +32,7 @@ export class RemoveTickerFromWatchlistUseCase {
     );
 
     if (watchlist.userId.value !== authContext.userId.value) {
-      throw new Error('User does not own this watchlist');
+      throw new AuthorizationError('User does not own this watchlist');
     }
 
     watchlist.removeTicker(request.ticker);

--- a/apps/backend/src/modules/watchlist/use-cases/rename-watchlist.use-case.ts
+++ b/apps/backend/src/modules/watchlist/use-cases/rename-watchlist.use-case.ts
@@ -5,6 +5,7 @@ import { WatchlistName } from '../domain/value-objects/watchlist-name';
 import type { WatchlistWriteRepository } from '../domain/repositories/watchlist-write.repository.interface';
 import type { AuthContext } from '../../auth/auth-context.interface';
 import { WATCHLIST_WRITE_REPOSITORY } from '../constants/tokens';
+import { AuthorizationError } from '../domain/domain-errors';
 
 export interface RenameWatchlistRequestDto {
   watchlistId: WatchlistId;
@@ -31,7 +32,7 @@ export class RenameWatchlistUseCase {
     );
 
     if (watchlist.userId.value !== authContext.userId.value) {
-      throw new Error('User does not own this watchlist');
+      throw new AuthorizationError('User does not own this watchlist');
     }
 
     watchlist.rename(request.name);


### PR DESCRIPTION
## Summary

Addresses the top findings from a full backend audit, plus a follow-up refactor and the tooling updates that prevent the same classes of issue recurring.

### Backend fixes (`da46ded`)
- **🔴 Closes a watchlist-monitoring IDOR (blocking).** All three monitoring use cases now take `authContext` and verify the caller owns the parent watchlist (loaded via `WATCHLIST_READ_REPOSITORY`) before acting; the controller threads `req.user` into each. Previously any authenticated user could activate/deactivate/read monitoring on **any** watchlist by guessing an id.
- **Domain errors → HTTP.** New shared `DomainError` base + `AuthorizationError` (403) / `NotFoundError` (404) in `src/common/errors`; each module's `domain-errors.ts` re-exports the shared base (one identity app-wide). New `DomainErrorFilter` (wired via `APP_FILTER`) maps `DomainError` subtypes to status codes by `instanceof`. Replaces the bare `throw new Error('User does not own …')` / not-found throws (which were leaking as **500s**) across `position` and `watchlist`.
- **Removed leftover `console.error` debug block** in `position-write.repository.ts`; the transaction propagates the error.
- **Sector-rotation cron** now uses the `CronJobNotificationService` start/success/error lifecycle (partial failure → failure), matching the `leader-scan` pattern.
- **Tests:** added unit specs for the three watchlist-monitoring use cases, covering the ownership-rejection and not-found paths (regression guard for the IDOR).

### Tooling (`1416d6f`)
- `backend-patterns` skill: replaced the bare-`Error` ownership example with `AuthorizationError`; documented the new error taxonomy + `src/common/errors` + `DomainErrorFilter`; made `authContext`+ownership mandatory and added child-resource (derive-from-parent) ownership.
- New `backend-security` skill: the auth/ownership threat model (authN ≠ authZ, IDOR, child-resource ownership, `@Public()` justification) + review checklist.
- `backend-auditor` agent: bare-`Error` ownership/not-found throws are now Tier-1; added Blocking checks for use cases missing `authContext`/ownership.

## Quality gates
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (10 pre-existing warnings, untouched)
- `npx jest` — **41 suites / 282 tests pass**

## Test plan
- [ ] Auth: a user activating/deactivating/reading monitoring on a watchlist they **don't** own gets **403** (not 500/200).
- [ ] Owner still gets normal behaviour on their own watchlist.
- [ ] Existing position/watchlist ownership violations now return **403**, not-found returns **404**.
- [ ] Sector-rotation weekly cron emits start/success (or error on partial failure) notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)