### PR TITLE
feat(watchlist-monitoring): GapDetectedEvent + Claude Code quality hooks

### DIFF
--- a/.claude/hooks/format-edited-file.mjs
+++ b/.claude/hooks/format-edited-file.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..', '..');
+
+function read(stream) {
+  return new Promise((res) => {
+    let data = '';
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => (data += chunk));
+    stream.on('end', () => res(data));
+    stream.on('error', () => res(''));
+  });
+}
+
+function workspaceFor(filePath) {
+  const rel = relative(REPO_ROOT, filePath);
+  if (rel.startsWith('apps/backend/')) return resolve(REPO_ROOT, 'apps/backend');
+  if (rel.startsWith('apps/frontend/')) return resolve(REPO_ROOT, 'apps/frontend');
+  return null;
+}
+
+function run(bin, args, cwd) {
+  return spawnSync('npx', [bin, ...args], { cwd, encoding: 'utf8' });
+}
+
+const raw = await read(process.stdin);
+let input;
+try {
+  input = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+const filePath = input?.tool_input?.file_path;
+if (!filePath || !existsSync(filePath)) process.exit(0);
+
+const abs = resolve(filePath);
+if (!abs.startsWith(REPO_ROOT)) process.exit(0);
+if (!/\.(ts|tsx|md)$/.test(abs)) process.exit(0);
+
+const prettier = run('prettier', ['--write', '--log-level', 'silent', abs], REPO_ROOT);
+if (prettier.status !== 0 && prettier.stderr) {
+  process.stderr.write(`prettier: ${prettier.stderr.trim()}\n`);
+}
+
+if (/\.(ts|tsx)$/.test(abs)) {
+  const ws = workspaceFor(abs);
+  if (ws) {
+    const eslint = run('eslint', ['--fix', '--no-warn-ignored', abs], ws);
+    if (eslint.status !== 0 && eslint.stdout) {
+      process.stderr.write(`eslint: ${eslint.stdout.trim()}\n`);
+    }
+  }
+}
+
+process.exit(0);

--- a/.claude/hooks/quality-gate.mjs
+++ b/.claude/hooks/quality-gate.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..', '..');
+
+function read(stream) {
+  return new Promise((res) => {
+    let data = '';
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => (data += chunk));
+    stream.on('end', () => res(data));
+    stream.on('error', () => res(''));
+  });
+}
+
+function git(args) {
+  const r = spawnSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' });
+  return r.status === 0 ? r.stdout : '';
+}
+
+function changedFiles() {
+  const out = new Set();
+  for (const line of git(['diff', '--name-only', 'HEAD']).split('\n')) {
+    if (line.trim()) out.add(line.trim());
+  }
+  for (const line of git(['ls-files', '--others', '--exclude-standard']).split('\n')) {
+    if (line.trim()) out.add(line.trim());
+  }
+  return [...out];
+}
+
+const WORKSPACES = {
+  backend: {
+    dir: 'apps/backend',
+    typecheck: ['npx', ['tsc', '--noEmit']],
+    lint: ['npx', ['eslint', '{src,apps,libs,test}/**/*.ts']],
+  },
+  frontend: {
+    dir: 'apps/frontend',
+    typecheck: ['npx', ['tsc', '-b', '--noEmit']],
+    lint: ['npx', ['eslint', '.']],
+  },
+};
+
+const raw = await read(process.stdin);
+try {
+  const input = JSON.parse(raw);
+  if (input?.stop_hook_active) process.exit(0);
+} catch {
+  // proceed even without parseable input
+}
+
+const touched = changedFiles();
+const active = Object.values(WORKSPACES).filter((w) =>
+  touched.some((f) => f.startsWith(w.dir + '/')),
+);
+
+if (active.length === 0) process.exit(0);
+
+const failures = [];
+
+for (const ws of active) {
+  const cwd = resolve(REPO_ROOT, ws.dir);
+
+  const [tcBin, tcArgs] = ws.typecheck;
+  const tc = spawnSync(tcBin, tcArgs, { cwd, encoding: 'utf8' });
+  if (tc.status !== 0) {
+    const out = `${tc.stdout ?? ''}${tc.stderr ?? ''}`.trim();
+    failures.push(`[${ws.dir}] type-check failed:\n${out}`);
+  }
+
+  const [ltBin, ltArgs] = ws.lint;
+  const lt = spawnSync(ltBin, ltArgs, { cwd, encoding: 'utf8' });
+  if (lt.status !== 0) {
+    const out = `${lt.stdout ?? ''}${lt.stderr ?? ''}`.trim();
+    failures.push(`[${ws.dir}] lint failed:\n${out}`);
+  }
+}
+
+if (failures.length === 0) process.exit(0);
+
+const message = [
+  'Quality gate failed on workspaces you changed this turn. Fix these before finishing:',
+  '',
+  ...failures,
+].join('\n');
+
+console.log(
+  JSON.stringify({
+    decision: 'block',
+    reason: message,
+  }),
+);
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/format-edited-file.mjs\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/quality-gate.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,10 @@ npx tsc --noEmit && npm run lint && npm run test
 - Incremental development: make one change, run quality gates, fix issues, proceed
 - Code should be self-explanatory: clear names and structure, not comments. Don't add comments by default — assume the code speaks for itself. Only comment when something genuinely can't be made clear in code (e.g. a non-obvious external constraint), and keep it rare
 - See apps/backend/CLAUDE.md and apps/frontend/CLAUDE.md for domain-specific conventions
+
+## Claude Code Hooks
+
+Hooks in `.claude/hooks/` (wired up in `.claude/settings.json`) automate the conventions above:
+
+- **`format-edited-file.mjs`** (PostToolUse on edits) — runs `prettier --write` + workspace-scoped `eslint --fix` on each edited `.ts/.tsx/.md` file. Keeps the tree formatted automatically.
+- **`quality-gate.mjs`** (Stop) — type-checks (`tsc --noEmit`) and lints any workspace with uncommitted changes; blocks turn completion and feeds failures back until they pass. Mirrors the `tsc --noEmit && lint` gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,4 +80,5 @@ npx tsc --noEmit && npm run lint && npm run test
 ## Coding Conventions
 
 - Incremental development: make one change, run quality gates, fix issues, proceed
+- Code should be self-explanatory: clear names and structure, not comments. Don't add comments by default — assume the code speaks for itself. Only comment when something genuinely can't be made clear in code (e.g. a non-obvious external constraint), and keep it rare
 - See apps/backend/CLAUDE.md and apps/frontend/CLAUDE.md for domain-specific conventions

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -32,6 +32,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/event-emitter": "^3.1.0",
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { LeaderScanModule } from './modules/leader-scan/leader-scan.module';
 import { StockClassificationModule } from './modules/stock-classification/stock-classification.module';
 import { AuthGuard } from './modules/auth/auth.guard';
 import { ScheduleModule } from '@nestjs/schedule';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { DatabaseModule } from './config/database.module';
 import { DomainErrorFilter } from './common/filters/domain-error.filter';
 
@@ -28,6 +29,7 @@ import { DomainErrorFilter } from './common/filters/domain-error.filter';
       envFilePath: '.env',
     }),
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot(),
     DatabaseModule,
     PositionModule,
     MarketDataModule,

--- a/apps/backend/src/modules/watchlist-monitoring/api/watchlist-monitoring.controller.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/api/watchlist-monitoring.controller.ts
@@ -1,9 +1,6 @@
 import { Body, Controller, Get, Param, Post, Req } from '@nestjs/common';
 import { WatchlistId } from '../../watchlist/domain/value-objects/watchlist-id';
-import {
-  MonitoringType,
-  isValidMonitoringType,
-} from '../domain/value-objects/monitoring-type';
+import { isValidMonitoringType } from '../domain/value-objects/monitoring-type';
 import type { AuthContext } from '../../auth/auth-context.interface';
 import type { AuthenticatedRequest } from '../../auth/types/request.interface';
 import { WatchlistMonitoringApiMapper } from './watchlist-monitoring-api.mapper';
@@ -74,7 +71,7 @@ export class WatchlistMonitoringController {
 
     const request: ActivateMonitoringRequestDto = {
       watchlistId: WatchlistId.of(watchlistId),
-      type: body.type as MonitoringType,
+      type: body.type,
     };
 
     const useCaseResponse = await this.activateMonitoringUseCase.execute(
@@ -103,7 +100,7 @@ export class WatchlistMonitoringController {
 
     const request: DeactivateMonitoringRequestDto = {
       watchlistId: WatchlistId.of(watchlistId),
-      type: body.type as MonitoringType,
+      type: body.type,
     };
 
     const useCaseResponse = await this.deactivateMonitoringUseCase.execute(

--- a/apps/backend/src/modules/watchlist-monitoring/domain/events/gap-detected.event.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/domain/events/gap-detected.event.ts
@@ -1,0 +1,15 @@
+import { WatchlistTicker } from '../../../watchlist/domain/value-objects/watchlist-ticker';
+import { WatchlistId } from '../../../watchlist/domain/value-objects/watchlist-id';
+import { LocalDate } from '../value-objects/local-date';
+
+export class GapDetectedEvent {
+  static readonly NAME = 'gap.detected';
+
+  constructor(
+    public readonly ticker: WatchlistTicker,
+    public readonly watchlistId: WatchlistId,
+    public readonly watchlistName: string,
+    public readonly marketDate: LocalDate,
+    public readonly detectedAt: Date,
+  ) {}
+}

--- a/apps/backend/src/modules/watchlist-monitoring/domain/value-objects/local-date.spec.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/domain/value-objects/local-date.spec.ts
@@ -1,0 +1,30 @@
+import { LocalDate } from './local-date';
+
+describe('LocalDate', () => {
+  it('round-trips through fromKey', () => {
+    const date = LocalDate.fromKey('2026-06-24');
+    expect(date.key).toBe('2026-06-24');
+  });
+
+  it('treats two dates with the same key as equal', () => {
+    expect(
+      LocalDate.fromKey('2026-06-24').equals(LocalDate.fromKey('2026-06-24')),
+    ).toBe(true);
+  });
+
+  it('treats different days as unequal', () => {
+    expect(
+      LocalDate.fromKey('2026-06-24').equals(LocalDate.fromKey('2026-06-25')),
+    ).toBe(false);
+  });
+
+  it('stringifies to its key', () => {
+    expect(LocalDate.fromKey('2026-06-24').toString()).toBe('2026-06-24');
+  });
+
+  it('rejects an invalid key', () => {
+    expect(() => LocalDate.fromKey('not-a-date')).toThrow(
+      'Invalid local date key',
+    );
+  });
+});

--- a/apps/backend/src/modules/watchlist-monitoring/domain/value-objects/local-date.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/domain/value-objects/local-date.ts
@@ -1,0 +1,27 @@
+import { DateTime } from 'luxon';
+
+const KEY_FORMAT = 'yyyy-LL-dd';
+
+export class LocalDate {
+  private constructor(private readonly date: DateTime) {}
+
+  static fromKey(key: string): LocalDate {
+    const parsed = DateTime.fromFormat(key, KEY_FORMAT, { zone: 'utc' });
+    if (!parsed.isValid) {
+      throw new Error(`Invalid local date key: ${key}`);
+    }
+    return new LocalDate(parsed.startOf('day'));
+  }
+
+  get key(): string {
+    return this.date.toFormat(KEY_FORMAT);
+  }
+
+  equals(other: LocalDate): boolean {
+    return this.key === other.key;
+  }
+
+  toString(): string {
+    return this.key;
+  }
+}

--- a/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/gap-detection.service.spec.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/gap-detection.service.spec.ts
@@ -110,7 +110,12 @@ describe('GapDetectionServiceImpl', () => {
 
     // Day D: closing vol must satisfy vol_ok, closing high sets the gap reference
     const dayD = priorSessionCount + 1;
-    bars.push(...buildSessionBars(dayD, { closingVol: dayDClosingVol, closingHigh: dayDHigh }));
+    bars.push(
+      ...buildSessionBars(dayD, {
+        closingVol: dayDClosingVol,
+        closingHigh: dayDHigh,
+      }),
+    );
 
     // Day D+1: first bar open must be > dayDHigh
     const dayD1 = dayD + 1;
@@ -169,7 +174,10 @@ describe('GapDetectionServiceImpl', () => {
   it('should return detected false when vol_ok fails (yesterday closing vol below 2x average)', async () => {
     const ticker = WatchlistTicker.of('AAPL');
     // avg_last_vol = 100, dayDClosingVol = 199 < 2.0 * 100 → vol_ok=false
-    const bars = buildGapScenario({ priorClosingVol: 100, dayDClosingVol: 199 });
+    const bars = buildGapScenario({
+      priorClosingVol: 100,
+      dayDClosingVol: 199,
+    });
     marketDataService.getHistoricalData.mockResolvedValue(historicalData(bars));
 
     const result = await service.detect(ticker);

--- a/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/market-time.util.spec.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/market-time.util.spec.ts
@@ -3,6 +3,7 @@ import {
   getMarketOpenDateUtc,
   isDuringMarketHours,
   isWithinMarketHours,
+  marketToday,
 } from './market-time.util';
 
 describe('market-time.util', () => {
@@ -21,6 +22,18 @@ describe('market-time.util', () => {
   it('should compute market date key in Toronto timezone', () => {
     const date = new Date('2025-02-15T03:00:00.000Z');
     expect(getMarketDateKey(date)).toBe('2025-02-14');
+  });
+
+  it('should map a late-evening ET instant to the Toronto calendar day', () => {
+    expect(marketToday(new Date('2026-06-25T03:00:00.000Z')).key).toBe(
+      '2026-06-24',
+    );
+  });
+
+  it('should treat two instants on the same Toronto day as the same market day', () => {
+    const morning = marketToday(new Date('2026-06-24T13:30:00.000Z'));
+    const afterClose = marketToday(new Date('2026-06-24T20:30:00.000Z'));
+    expect(morning.equals(afterClose)).toBe(true);
   });
 
   it('should identify market hours boundaries using Toronto local time', () => {

--- a/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/market-time.util.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/market-time.util.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import { LocalDate } from '../../domain/value-objects/local-date';
 
 const MARKET_TIMEZONE = 'America/Toronto';
 const MARKET_OPEN_HOUR = 9;
@@ -6,10 +7,15 @@ const MARKET_OPEN_MINUTE = 30;
 const MARKET_CLOSE_HOUR = 16;
 const MARKET_CLOSE_MINUTE = 0;
 
-export function getMarketDateKey(now: Date = new Date()): string {
-  return DateTime.fromJSDate(now, { zone: MARKET_TIMEZONE }).toFormat(
+export function marketToday(now: Date = new Date()): LocalDate {
+  const key = DateTime.fromJSDate(now, { zone: MARKET_TIMEZONE }).toFormat(
     'yyyy-LL-dd',
   );
+  return LocalDate.fromKey(key);
+}
+
+export function getMarketDateKey(now: Date = new Date()): string {
+  return marketToday(now).key;
 }
 
 export function getMarketOpenDateUtc(now: Date = new Date()): Date {

--- a/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/watchlist-monitoring-cron.service.spec.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/watchlist-monitoring-cron.service.spec.ts
@@ -1,0 +1,154 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { WatchlistMonitoringCronService } from './watchlist-monitoring-cron.service';
+import { GapDetectedEvent } from '../../domain/events/gap-detected.event';
+import { LocalDate } from '../../domain/value-objects/local-date';
+import { MonitoringType } from '../../domain/value-objects/monitoring-type';
+import { getMarketDateKey } from './market-time.util';
+import { Watchlist } from '../../../watchlist/domain/entities/watchlist';
+import { WatchlistId } from '../../../watchlist/domain/value-objects/watchlist-id';
+import { WatchlistName } from '../../../watchlist/domain/value-objects/watchlist-name';
+import { WatchlistTicker } from '../../../watchlist/domain/value-objects/watchlist-ticker';
+import { UserId } from '../../../position/domain/value-objects/user-id';
+import type { WatchlistMonitoringReadRepository } from '../../domain/repositories/watchlist-monitoring-read.repository.interface';
+import type { MonitoringAlertLogRepository } from '../../domain/repositories/monitoring-alert-log.repository.interface';
+import type { WatchlistReadRepository } from '../../../watchlist/domain/repositories/watchlist-read.repository.interface';
+import type { BreakoutDetectionService } from '../../domain/services/breakout-detection.service';
+import type { GapDetectionService } from '../../domain/services/gap-detection.service';
+import type { NotificationService } from '../../../notification/domain/services/notification.service';
+import {
+  WATCHLIST_MONITORING_READ_REPOSITORY,
+  BREAKOUT_DETECTION_SERVICE,
+  GAP_DETECTION_SERVICE,
+  MONITORING_ALERT_LOG_REPOSITORY,
+} from '../../constants/tokens';
+import { WATCHLIST_READ_REPOSITORY } from '../../../watchlist/constants/tokens';
+import { NOTIFICATION_SERVICE } from '../../../notification/constants/tokens';
+
+describe('WatchlistMonitoringCronService — gap event emission', () => {
+  let service: WatchlistMonitoringCronService;
+  let monitoringReadRepository: jest.Mocked<WatchlistMonitoringReadRepository>;
+  let alertLogRepository: jest.Mocked<MonitoringAlertLogRepository>;
+  let watchlistReadRepository: jest.Mocked<WatchlistReadRepository>;
+  let gapDetectionService: jest.Mocked<GapDetectionService>;
+  let notificationService: jest.Mocked<NotificationService>;
+  let eventEmitter: EventEmitter2;
+  let emitSpy: jest.SpyInstance;
+
+  const watchlistId = WatchlistId.of('wl-123');
+  const ticker = WatchlistTicker.of('AAPL');
+
+  function buildWatchlist(): Watchlist {
+    const wl = Watchlist.fromData({
+      id: watchlistId,
+      userId: UserId.of('user-1'),
+      name: WatchlistName.of('Momentum'),
+      tickers: [ticker],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return wl;
+  }
+
+  beforeEach(async () => {
+    monitoringReadRepository = {
+      findByWatchlistId: jest.fn(),
+      findByWatchlistIdAndType: jest.fn(),
+      findAllActive: jest.fn(),
+      findAllActiveByType: jest
+        .fn()
+        .mockResolvedValue([{ watchlistId } as never]),
+    };
+    alertLogRepository = {
+      hasAlerted: jest.fn().mockResolvedValue(false),
+      recordAlert: jest.fn().mockResolvedValue(undefined),
+    };
+    watchlistReadRepository = {
+      findById: jest.fn().mockResolvedValue(buildWatchlist()),
+    } as unknown as jest.Mocked<WatchlistReadRepository>;
+    gapDetectionService = {
+      detect: jest.fn().mockResolvedValue({ ticker, detected: true }),
+    };
+    notificationService = { send: jest.fn().mockResolvedValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WatchlistMonitoringCronService,
+        EventEmitter2,
+        {
+          provide: WATCHLIST_MONITORING_READ_REPOSITORY,
+          useValue: monitoringReadRepository,
+        },
+        {
+          provide: MONITORING_ALERT_LOG_REPOSITORY,
+          useValue: alertLogRepository,
+        },
+        {
+          provide: WATCHLIST_READ_REPOSITORY,
+          useValue: watchlistReadRepository,
+        },
+        {
+          provide: BREAKOUT_DETECTION_SERVICE,
+          useValue: { detect: jest.fn() } as Partial<BreakoutDetectionService>,
+        },
+        { provide: GAP_DETECTION_SERVICE, useValue: gapDetectionService },
+        { provide: NOTIFICATION_SERVICE, useValue: notificationService },
+      ],
+    }).compile();
+
+    service = module.get(WatchlistMonitoringCronService);
+    eventEmitter = module.get(EventEmitter2);
+    emitSpy = jest.spyOn(eventEmitter, 'emit');
+  });
+
+  it('emits a GapDetectedEvent on first detection, with the full payload', async () => {
+    let emittedName: string | undefined;
+    let emittedEvent: GapDetectedEvent | undefined;
+    emitSpy.mockImplementation((name: string, payload: GapDetectedEvent) => {
+      emittedName = name;
+      emittedEvent = payload;
+      return true;
+    });
+
+    await service.monitorGaps();
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emittedName).toBe(GapDetectedEvent.NAME);
+    expect(emittedEvent).toBeInstanceOf(GapDetectedEvent);
+    const gapEvent = emittedEvent as GapDetectedEvent;
+    expect(gapEvent.ticker.value).toBe('AAPL');
+    expect(gapEvent.watchlistId.value).toBe('wl-123');
+    expect(gapEvent.watchlistName).toBe('Momentum');
+    expect(gapEvent.marketDate).toBeInstanceOf(LocalDate);
+    expect(gapEvent.marketDate.key).toBe(getMarketDateKey());
+    expect(gapEvent.detectedAt).toBeInstanceOf(Date);
+  });
+
+  it('does not emit when no gap is detected', async () => {
+    gapDetectionService.detect.mockResolvedValue({ ticker, detected: false });
+
+    await service.monitorGaps();
+
+    expect(emitSpy).not.toHaveBeenCalled();
+    expect(notificationService.send).not.toHaveBeenCalled();
+  });
+
+  it('does not emit when already alerted today (de-dup gate)', async () => {
+    alertLogRepository.hasAlerted.mockResolvedValue(true);
+
+    await service.monitorGaps();
+
+    expect(emitSpy).not.toHaveBeenCalled();
+    expect(alertLogRepository.recordAlert).not.toHaveBeenCalled();
+  });
+
+  it('records the GAP alert when it emits', async () => {
+    await service.monitorGaps();
+
+    expect(alertLogRepository.recordAlert).toHaveBeenCalledWith(
+      'AAPL',
+      getMarketDateKey(),
+      MonitoringType.GAP,
+    );
+  });
+});

--- a/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/watchlist-monitoring-cron.service.ts
+++ b/apps/backend/src/modules/watchlist-monitoring/infrastructure/services/watchlist-monitoring-cron.service.ts
@@ -1,6 +1,8 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MonitoringType } from '../../domain/value-objects/monitoring-type';
+import { GapDetectedEvent } from '../../domain/events/gap-detected.event';
 import { WatchlistId } from '../../../watchlist/domain/value-objects/watchlist-id';
 import { NotificationTopic } from '../../../notification/domain/value-objects/notification-topic';
 import { NotificationMessage } from '../../../notification/domain/value-objects/notification-message';
@@ -18,7 +20,11 @@ import { GAP_DETECTION_SERVICE } from '../../constants/tokens';
 import { MONITORING_ALERT_LOG_REPOSITORY } from '../../constants/tokens';
 import { WATCHLIST_READ_REPOSITORY } from '../../../watchlist/constants/tokens';
 import { NOTIFICATION_SERVICE } from '../../../notification/constants/tokens';
-import { getMarketDateKey, isWithinMarketHours } from './market-time.util';
+import {
+  getMarketDateKey,
+  isWithinMarketHours,
+  marketToday,
+} from './market-time.util';
 
 @Injectable()
 export class WatchlistMonitoringCronService {
@@ -39,6 +45,7 @@ export class WatchlistMonitoringCronService {
     private readonly gapDetectionService: GapDetectionService,
     @Inject(NOTIFICATION_SERVICE)
     private readonly notificationService: NotificationService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   @Cron('*/5 * * * 1-5', { timeZone: 'America/Toronto' })
@@ -175,20 +182,32 @@ export class WatchlistMonitoringCronService {
       try {
         const result = await this.gapDetectionService.detect(ticker);
 
-        const marketDate = getMarketDateKey();
+        const detectedAt = new Date();
+        const marketDate = marketToday(detectedAt);
         if (
           result.detected &&
           !(await this.monitoringAlertLogRepository.hasAlerted(
             ticker.value,
-            marketDate,
+            marketDate.key,
             MonitoringType.GAP,
           ))
         ) {
           await this.sendGapAlert(ticker.value, watchlist.name.value);
           await this.monitoringAlertLogRepository.recordAlert(
             ticker.value,
-            marketDate,
+            marketDate.key,
             MonitoringType.GAP,
+          );
+
+          this.eventEmitter.emit(
+            GapDetectedEvent.NAME,
+            new GapDetectedEvent(
+              ticker,
+              watchlist.id,
+              watchlist.name.value,
+              marketDate,
+              detectedAt,
+            ),
           );
         }
       } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
+        "@nestjs/event-emitter": "^3.1.0",
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
@@ -3135,6 +3136,19 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-3.1.0.tgz",
+      "integrity": "sha512-DOY/4XBGyIjYyOJKkO6jl1kzFE0ZfX0wV+M2HR5NWymPT9Z0zdCEcZGxTXXkoMRwPtglnvCGJALSjOpXPIcM3g==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/jwt": {
@@ -8539,6 +8553,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",


### PR DESCRIPTION
## Summary

Two related changes on this branch:

1. **`GapDetectedEvent` on gap detection** — the gap-monitoring cron now emits a domain event (via `@nestjs/event-emitter`) inside the existing once-per-day de-dup gate, alongside the notification. Adds a `LocalDate` value object and a `marketToday()` helper for Toronto-timezone market-day resolution.
2. **Claude Code quality hooks** — `.claude/hooks/` + `.claude/settings.json`:
   - `format-edited-file.mjs` (PostToolUse): `prettier --write` + workspace-scoped `eslint --fix` on each edited `.ts/.tsx/.md` file.
   - `quality-gate.mjs` (Stop): `tsc --noEmit` + `eslint` on any workspace with uncommitted changes, blocking turn completion and feeding failures back until they pass.

## Notes

- The gate calls `tsc`/`eslint` directly because the `check-types` npm script delegates to a turbo task neither workspace defines — it was a no-op, so the documented type-check gate never actually ran.
- Gate lint runs **without** `--fix` (read-only check); fixing is the format hook's job, so the gate never silently mutates files at end-of-turn.
- Adopts a repo-wide convention: code should be self-explanatory, comments by default avoided (codified in CLAUDE.md).

## Test plan

- `tsc --noEmit` clean, `eslint` 0 errors, `jest` 51/51 pass on the watchlist-monitoring module.
- Hooks verified end-to-end: format hook formats/ignores correctly; gate passes on a clean tree and blocks with fed-back compiler+lint output on an injected error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)