### PR TITLE
feat(paper-trading): surface gap-trade context in recent trade rows

### DIFF
--- a/apps/backend/src/modules/paper-trading/api/paper-trading-api.dto.ts
+++ b/apps/backend/src/modules/paper-trading/api/paper-trading-api.dto.ts
@@ -1,3 +1,10 @@
+export interface PaperTradeContextApiDto {
+  industryGroup: string | null;
+  globalRsRating: number | null;
+  industryGroupRsRating: number | null;
+  industryGroupQuadrant: string | null;
+}
+
 export interface PaperTradeApiDto {
   id: string;
   ticker: string;
@@ -14,6 +21,7 @@ export interface PaperTradeApiDto {
   marketDate: string;
   openedAt: string;
   closedAt: string | null;
+  context: PaperTradeContextApiDto;
 }
 
 export interface PaperTradingStatsApiDto {

--- a/apps/backend/src/modules/paper-trading/api/paper-trading-api.mapper.ts
+++ b/apps/backend/src/modules/paper-trading/api/paper-trading-api.mapper.ts
@@ -25,6 +25,12 @@ export class PaperTradingApiMapper {
       marketDate: trade.marketDate,
       openedAt: trade.openedAt.toISOString(),
       closedAt: trade.closedAt ? trade.closedAt.toISOString() : null,
+      context: {
+        industryGroup: trade.context.industryGroup,
+        globalRsRating: trade.context.globalRsRating,
+        industryGroupRsRating: trade.context.industryGroupRsRating,
+        industryGroupQuadrant: trade.context.industryGroupQuadrant,
+      },
     };
   }
 

--- a/apps/frontend/src/paper-trading/api/paper-trading.types.ts
+++ b/apps/frontend/src/paper-trading/api/paper-trading.types.ts
@@ -2,6 +2,19 @@ export type PaperTradeStatus = "OPEN" | "CLOSED";
 
 export type PaperTradeExitReason = "STOP" | "TARGET";
 
+export type PaperTradeQuadrant =
+  | "Leading"
+  | "Weakening"
+  | "Lagging"
+  | "Improving";
+
+export interface PaperTradeContext {
+  industryGroup: string | null;
+  globalRsRating: number | null;
+  industryGroupRsRating: number | null;
+  industryGroupQuadrant: PaperTradeQuadrant | null;
+}
+
 export interface PaperTrade {
   id: string;
   ticker: string;
@@ -18,6 +31,7 @@ export interface PaperTrade {
   marketDate: string;
   openedAt: string;
   closedAt: string | null;
+  context: PaperTradeContext;
 }
 
 export interface PaperTradingStats {

--- a/apps/frontend/src/paper-trading/components/PaperTradingCard.tsx
+++ b/apps/frontend/src/paper-trading/components/PaperTradingCard.tsx
@@ -13,7 +13,20 @@ import {
   usePaperTradingStats,
   usePaperTrades,
 } from "../hooks/use-paper-trading";
-import type { PaperTrade } from "../api/paper-trading.types";
+import type {
+  PaperTrade,
+  PaperTradeQuadrant,
+} from "../api/paper-trading.types";
+
+const QUADRANT_VARIANT: Record<
+  PaperTradeQuadrant,
+  "success" | "danger" | "warning" | "secondary"
+> = {
+  Leading: "success",
+  Improving: "warning",
+  Weakening: "secondary",
+  Lagging: "danger",
+};
 
 function Stat({
   label,
@@ -44,27 +57,62 @@ function RecentTradeRow({ trade }: { trade: PaperTrade }) {
   const rText =
     trade.realizedR !== null ? `${trade.realizedR.toFixed(2)}R` : "open";
 
+  const { context } = trade;
+  const hasRsContext =
+    context.globalRsRating !== null || context.industryGroupRsRating !== null;
+  const hasContext =
+    context.industryGroup !== null ||
+    context.industryGroupQuadrant !== null ||
+    hasRsContext;
+
   return (
-    <div className="flex items-center justify-between py-1.5 text-sm">
-      <div className="flex items-center gap-2">
-        <span className="font-medium text-slate-900 dark:text-slate-50">
-          {trade.ticker}
+    <div className="space-y-1 py-1.5 text-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-slate-900 dark:text-slate-50">
+            {trade.ticker}
+          </span>
+          {!isClosed && (
+            <Badge variant="secondary" className="text-[10px]">
+              OPEN
+            </Badge>
+          )}
+          {context.industryGroupQuadrant !== null && (
+            <Badge
+              variant={QUADRANT_VARIANT[context.industryGroupQuadrant]}
+              className="text-[10px]"
+            >
+              {context.industryGroupQuadrant}
+            </Badge>
+          )}
+        </div>
+        <span
+          className={`font-mono ${
+            trade.realizedR === null
+              ? "text-slate-400 dark:text-slate-500"
+              : getChangeColor(trade.realizedR)
+          }`}
+        >
+          {rText}
         </span>
-        {!isClosed && (
-          <Badge variant="secondary" className="text-[10px]">
-            OPEN
-          </Badge>
-        )}
       </div>
-      <span
-        className={`font-mono ${
-          trade.realizedR === null
-            ? "text-slate-400 dark:text-slate-500"
-            : getChangeColor(trade.realizedR)
-        }`}
-      >
-        {rText}
-      </span>
+      {hasContext && (
+        <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+          {context.industryGroup !== null && (
+            <span className="truncate">{context.industryGroup}</span>
+          )}
+          {hasRsContext && (
+            <span className="ml-auto shrink-0 font-mono">
+              RS{" "}
+              {context.globalRsRating !== null ? context.globalRsRating : "—"}
+              {" / "}
+              {context.industryGroupRsRating !== null
+                ? context.industryGroupRsRating
+                : "—"}
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The gap-trade context enrichment (GICS industry group, global RS rating, industry-group RS rating, RRG quadrant) was captured at detection and persisted to `paper_trades` in #18, but **dropped at the API boundary** — `mapTrade` ended at `closedAt` — so it never reached the dashboard. The enrichment was effectively write-only.

This wires it through end-to-end and surfaces it in the dashboard's recent trade rows.

## Changes

**Backend (the layer that was dropping it):**
- `paper-trading-api.dto.ts` — new `PaperTradeContextApiDto` (4 nullable fields) + `context` on `PaperTradeApiDto`
- `paper-trading-api.mapper.ts` — `mapTrade` now emits `trade.context`

**Frontend:**
- `paper-trading.types.ts` — `PaperTradeContext` + `PaperTradeQuadrant`, added to `PaperTrade`
- `PaperTradingCard.tsx` — `RecentTradeRow` now shows:
  - a color-mapped **RRG quadrant** badge — Leading → success, Improving → warning, Weakening → secondary, Lagging → danger
  - a sub-line with the **industry group** and **`RS {global} / {industryGroup}`**
  - each field renders independently; the sub-line hides entirely when a trade has no context, matching the backend's best-effort enrichment (any field can be null)

No new computation, no migration — pure plumbing of already-persisted data.

## Test plan
- [x] Backend `tsc --noEmit` — clean
- [x] Frontend `tsc --noEmit` — clean
- [x] Backend paper-trading tests — 28/28 pass (incl. repo integration round-tripping the context columns)
- [x] Backend + frontend lint — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)